### PR TITLE
Implement intelligent review statuses and isolate invalid images

### DIFF
--- a/infra/migrations/1787145430440_update-status-constraints.js
+++ b/infra/migrations/1787145430440_update-status-constraints.js
@@ -1,0 +1,27 @@
+exports.up = (pgm) => {
+  pgm.dropConstraint("trash_detections", "check_review_status_enum", {
+    ifExists: true,
+  });
+  pgm.addConstraint("trash_detections", "check_review_status_enum", {
+    check:
+      "review_status IN ('pending', 'processing', 'approved', 'corrected', 'invalid', 'not_applicable')",
+  });
+
+  pgm.dropConstraint("trash_detections", "check_dataset_status_enum", {
+    ifExists: true,
+  });
+  pgm.addConstraint("trash_detections", "check_dataset_status_enum", {
+    check:
+      "dataset_status IN ('pending', 'eligible', 'included', 'excluded', 'ignored')",
+  });
+
+  pgm.dropConstraint("trash_detections", "check_storage_status_enum", {
+    ifExists: true,
+  });
+  pgm.addConstraint("trash_detections", "check_storage_status_enum", {
+    check:
+      "storage_status IN ('pending', 'copying', 'stored', 'failed', 'ignored', 'cleanup_pending')",
+  });
+};
+
+exports.down = false;

--- a/models/trashEvent.js
+++ b/models/trashEvent.js
@@ -62,7 +62,7 @@ async function create(eventData) {
 }
 
 async function review(eventId, validatedClass, reviewerId) {
-  if (!isValidClass(validatedClass)) {
+  if (!isValidClass(validatedClass) && validatedClass !== "invalid_image") {
     const error = new Error(`Classe validada inválida: ${validatedClass}`);
     error.name = "ValidationError";
     throw error;
@@ -72,10 +72,22 @@ async function review(eventId, validatedClass, reviewerId) {
     text: `
       UPDATE trash_detections 
       SET 
-        review_status = 'approved',
-        dataset_status = 'eligible',
-        item_class = $1, 
-        reviewed_by = $2
+        review_status = CASE
+          WHEN $1 = 'invalid_image' THEN 'invalid'
+          WHEN ai_prediction = $1 THEN 'approved'
+          ELSE 'corrected'
+        END,
+        dataset_status = CASE
+          WHEN $1 = 'invalid_image' THEN 'excluded'
+          ELSE 'eligible'
+        END,
+        item_class = CASE
+          WHEN $1 = 'invalid_image' THEN item_class
+          ELSE $1
+        END,
+        reviewed_by = $2,
+        reviewed_at = NOW(),
+        updated_at = NOW()
       WHERE id = $3 AND review_status = 'pending'
       RETURNING *;
     `,

--- a/pages/api/v1/trash-events/[id]/index.js
+++ b/pages/api/v1/trash-events/[id]/index.js
@@ -124,7 +124,10 @@ async function patchHandler(request, response) {
     });
   }
 
-  const newPath = `dataset/${correctClass}/${id}.jpg`;
+  const newPath =
+    correctClass === "invalid_image"
+      ? `rejected/invalid-image/${id}.jpg`
+      : `dataset/${correctClass}/${id}.jpg`;
 
   try {
     await s3Client.send(
@@ -152,10 +155,20 @@ async function patchHandler(request, response) {
     text: `
       UPDATE trash_detections 
       SET 
-        review_status = 'approved',
+        review_status = CASE
+          WHEN $1 = 'invalid_image' THEN 'invalid'
+          WHEN ai_prediction = $1 THEN 'approved'
+          ELSE 'corrected'
+        END,
         storage_status = 'stored',
-        dataset_status = 'eligible',
-        item_class = $1, 
+        dataset_status = CASE
+          WHEN $1 = 'invalid_image' THEN 'excluded'
+          ELSE 'eligible'
+        END,
+        item_class = CASE
+          WHEN $1 = 'invalid_image' THEN item_class
+          ELSE $1
+        END,
         image_path = $2, 
         reviewed_by = $3,
         updated_at = NOW(),

--- a/tests/integration/api/v1/trash-events/patch.test.js
+++ b/tests/integration/api/v1/trash-events/patch.test.js
@@ -42,7 +42,7 @@ describe("PATCH /api/v1/trash-events/[id]", () => {
 
     const updatedEvent = dbResult.rows[0];
 
-    expect(updatedEvent.review_status).toBe("approved");
+    expect(updatedEvent.review_status).toBe("corrected");
     expect(updatedEvent.storage_status).toBe("stored");
     expect(updatedEvent.dataset_status).toBe("eligible");
     expect(updatedEvent.item_class).toBe("cardboard");


### PR DESCRIPTION
* R2 Routing: Updated `pages/api/v1/trash-events/[id]/index.js` to route `invalid_image` items to a separate `rejected/invalid-image/` directory in S3/R2, preventing unclassifiable images from contaminating the training dataset.
* SQL Logic: Replaced hardcoded 'approved' status with a `CASE WHEN` clause that compares the human `correctClass` against the `ai_prediction`. Matches are marked `approved`, mismatches are `corrected`, and rejected items become `invalid`.
* Dataset Status: Invalid items now correctly receive a `dataset_status` of `excluded` and maintain their original `item_class` instead of adopting the 'invalid_image' string as a physical class.
* Model Synchronization: Mirrored the conditional SQL query into the `trashEvent.review()` function for consistency across the application.

new database migration following the project's standard format (no exports.down) to support the expanded vocabulary of item states required by the new audit architecture.

* Dropped old, restrictive `check_review_status_enum` and `check_dataset_status_enum` constraints on the `trash_detections` table.
* Added updated constraints to permit `corrected`, `invalid`, and `excluded` states, resolving the 503/ServiceError thrown during API integration tests when the backend attempted to save the new dynamic validation statuses.
* Expanded `storage_status` constraints to future-proof upcoming R2 cleanup and copying jobs.