### PR TITLE
R2 error

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -18,7 +18,8 @@ function onErrorHandler(error, request, response) {
     error.name === "ValidationError" ||
     error.name === "NotFoundError" ||
     error.name === "ForbiddenError" ||
-    error.name === "ServiceError"
+    error.name === "ServiceError" ||
+    error.name === "ConcurrencyError"
   ) {
     return response.status(error.statusCode || 400).json(error);
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -138,3 +138,23 @@ export class UnauthorizedError extends Error {
     };
   }
 }
+
+export class ConcurrencyError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Ocorreu um conflito de concorrência no recurso.", {
+      cause,
+    });
+    this.name = "ConcurrencyError";
+    this.action = action || "Atualize a página ou os dados e tente novamente.";
+    this.statusCode = 409;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/pages/api/v1/trash-events/[id]/index.js
+++ b/pages/api/v1/trash-events/[id]/index.js
@@ -6,6 +6,7 @@ import {
   ForbiddenError,
   ServiceError,
   UnauthorizedError,
+  ConcurrencyError,
 } from "infra/errors.js";
 import controller from "infra/controller.js";
 import database from "infra/database.js";
@@ -118,9 +119,9 @@ async function patchHandler(request, response) {
   }
 
   if (trashEvent.review_status !== "pending") {
-    return response.status(409).json({
-      name: "ConcurrencyError",
+    throw new ConcurrencyError({
       message: "Esta imagem já foi validada anteriormente.",
+      action: "A imagem não está mais disponível para revisão.",
     });
   }
 
@@ -181,9 +182,27 @@ async function patchHandler(request, response) {
   });
 
   if (updateResult.rowCount === 0) {
-    return response.status(409).json({
-      name: "ConcurrencyError",
+    try {
+      await s3Client.send(
+        new DeleteObjectCommand({
+          Bucket: process.env.R2_BUCKET_NAME,
+          Key: newPath,
+        }),
+      );
+    } catch (cleanupError) {
+      console.error(
+        "[S3 Error] Falha ao limpar arquivo órfão após conflito de concorrência:",
+        {
+          detectionId: id,
+          objectKey: newPath,
+          errorMessage: cleanupError.message,
+        },
+      );
+    }
+
+    throw new ConcurrencyError({
       message: "Este item já foi revisado por outro usuário.",
+      action: "A imagem foi removida da sua fila. Continue para a próxima.",
     });
   }
 


### PR DESCRIPTION
* Added a `DeleteObjectCommand` inside the concurrency error catch block (`rowCount === 0`) in the `PATCH /api/v1/trash-events/[id]` endpoint. 
* If two reviewers attempt to validate the same pending image simultaneously, the system now gracefully deletes the duplicated dataset image generated by the losing request before returning the 409 Conflict response.